### PR TITLE
Moved to nodenv org

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,16 +1,16 @@
 # Homebrew-nodenv
 
-[![Build Status](https://img.shields.io/travis/jawshooah/homebrew-nodenv/master.svg)](https://travis-ci.org/jawshooah/homebrew-nodenv)
+[![Build Status](https://img.shields.io/travis/nodenv/homebrew-nodenv/master.svg)](https://travis-ci.org/nodenv/homebrew-nodenv)
 
-This tap provides Homebrew formulae for [plugins](https://github.com/OiNutter/nodenv/wiki/Plugins) extending [nodenv](https://github.com/OiNutter/nodenv).
+This tap provides Homebrew formulae for [plugins](https://github.com/nodenv/nodenv/wiki/Plugins) extending [nodenv](https://github.com/nodenv/nodenv).
 
 ## Installing Homebrew-nodenv Formulae
-Just `brew tap jawshooah/nodenv` and then `brew install <formula>`. You only need to tap the repository once.
+Just `brew tap nodenv/nodenv` and then `brew install <formula>`. You only need to tap the repository once.
 
 You can also install via URL:
 
 ```
-brew install https://raw.githubusercontent.com/jawshooah/homebrew-nodenv/master/<formula>.rb
+brew install https://raw.githubusercontent.com/nodenv/homebrew-nodenv/master/<formula>.rb
 ```
 
 ## Troubleshooting
@@ -29,4 +29,4 @@ Second, read the [Homebrew Troubleshooting Checklist](https://github.com/Homebre
 Have a look at the [Homebrew Formula Cookbook](https://github.com/Homebrew/homebrew/blob/master/share/doc/homebrew/Formula-Cookbook.md).  In particular, your formula should pass `brew audit --strict <formula>` and `brew test <formula>`.
 
 ## License
-Code is under the [MIT license](https://github.com/jawshooah/homebrew-nodenv/tree/master/LICENSE.txt).
+Code is under the [MIT license](https://github.com/nodenv/homebrew-nodenv/tree/master/LICENSE.txt).

--- a/node-build-update-defs.rb
+++ b/node-build-update-defs.rb
@@ -1,9 +1,9 @@
 class NodeBuildUpdateDefs < Formula
   desc "Scrape build definitions from nodejs.org and iojs.org"
-  homepage "https://github.com/jasonkarns/node-build-update-defs"
-  url "https://github.com/jasonkarns/node-build-update-defs/archive/v1.0.0.tar.gz"
+  homepage "https://github.com/nodenv/node-build-update-defs"
+  url "https://github.com/nodenv/node-build-update-defs/archive/v1.0.0.tar.gz"
   sha256 "a17534fa793cdb9a7c75f75602ee2e3337799c3c8326000b8ceed5d77d8e8429"
-  head "https://github.com/jasonkarns/node-build-update-defs.git"
+  head "https://github.com/nodenv/node-build-update-defs.git"
 
   depends_on "nodenv"
   depends_on "node-build"

--- a/nodenv-aliases.rb
+++ b/nodenv-aliases.rb
@@ -1,9 +1,9 @@
 class NodenvAliases < Formula
   desc "Create aliases for nodenv Node versions"
-  homepage "https://github.com/jasonkarns/nodenv-aliases"
-  url "https://github.com/jasonkarns/nodenv-aliases/archive/v1.0.1.tar.gz"
+  homepage "https://github.com/nodenv/nodenv-aliases"
+  url "https://github.com/nodenv/nodenv-aliases/archive/v1.0.1.tar.gz"
   sha256 "115e3f482bf0c07f134bdb5aec9c1b88f057f60d0b87f34025fed79630e783a2"
-  head "https://github.com/jasonkarns/nodenv-aliases.git"
+  head "https://github.com/nodenv/nodenv-aliases.git"
 
   depends_on "nodenv"
 

--- a/nodenv-default-packages.rb
+++ b/nodenv-default-packages.rb
@@ -1,9 +1,9 @@
 class NodenvDefaultPackages < Formula
   desc "Auto-installs packages for Node installs"
-  homepage "https://github.com/jawshooah/nodenv-default-packages"
-  url "https://github.com/jawshooah/nodenv-default-packages/archive/0.1.0.tar.gz"
+  homepage "https://github.com/nodenv/nodenv-default-packages"
+  url "https://github.com/nodenv/nodenv-default-packages/archive/0.1.0.tar.gz"
   sha256 "645a60340f4d498c656740bddf480e2cc079b8d371800458c5dc8a92c8909890"
-  head "https://github.com/jawshooah/nodenv-default-packages.git"
+  head "https://github.com/nodenv/nodenv-default-packages.git"
 
   depends_on "nodenv"
   depends_on "node-build"

--- a/nodenv-each.rb
+++ b/nodenv-each.rb
@@ -1,9 +1,9 @@
 class NodenvEach < Formula
   desc "Run a command against all installed versions of Node"
-  homepage "https://github.com/jasonkarns/nodenv-each"
-  url "https://github.com/jasonkarns/nodenv-each/archive/v1.0.0.tar.gz"
+  homepage "https://github.com/nodenv/nodenv-each"
+  url "https://github.com/nodenv/nodenv-each/archive/v1.0.0.tar.gz"
   sha256 "a6e32cfc029407d92dc9d193037a647247ed65ead9187ffaf953abacf8b6b94e"
-  head "https://github.com/jasonkarns/nodenv-each.git"
+  head "https://github.com/nodenv/nodenv-each.git"
 
   depends_on "nodenv"
 

--- a/nodenv-npm-migrate.rb
+++ b/nodenv-npm-migrate.rb
@@ -1,9 +1,9 @@
 class NodenvNpmMigrate < Formula
   desc "Migrate npm packages from one Node version to another"
-  homepage "https://github.com/jawshooah/nodenv-npm-migrate"
-  url "https://github.com/jawshooah/nodenv-npm-migrate/archive/0.1.0.tar.gz"
+  homepage "https://github.com/nodenv/nodenv-npm-migrate"
+  url "https://github.com/nodenv/nodenv-npm-migrate/archive/0.1.0.tar.gz"
   sha256 "4c35dae6a6ca79a8b00083989b4dc18d5cb0d8bb2651de48e3996ab85403e225"
-  head "https://github.com/jawshooah/nodenv-npm-migrate.git"
+  head "https://github.com/nodenv/nodenv-npm-migrate.git"
 
   depends_on "nodenv"
 

--- a/nodenv-package-rehash.rb
+++ b/nodenv-package-rehash.rb
@@ -1,9 +1,9 @@
 class NodenvPackageRehash < Formula
   desc "Automatically runs `nodenv rehash`"
-  homepage "https://github.com/jasonkarns/nodenv-package-rehash"
-  url "https://github.com/jasonkarns/nodenv-package-rehash/archive/v1.0.2.tar.gz"
+  homepage "https://github.com/nodenv/nodenv-package-rehash"
+  url "https://github.com/nodenv/nodenv-package-rehash/archive/v1.0.2.tar.gz"
   sha256 "7811b5fc85e472c93fe7f83f72a7a34c82f31d2fee671ab6e6ba8b44ee2071b0"
-  head "https://github.com/jasonkarns/nodenv-package-rehash.git"
+  head "https://github.com/nodenv/nodenv-package-rehash.git"
 
   depends_on "nodenv"
 

--- a/nodenv-vars.rb
+++ b/nodenv-vars.rb
@@ -1,9 +1,9 @@
 class NodenvVars < Formula
   desc "Safely sets global and per-project environment variables"
-  homepage "https://github.com/OiNutter/nodenv-vars"
-  url "https://github.com/OiNutter/nodenv-vars/archive/v1.2.0.tar.gz"
+  homepage "https://github.com/nodenv/nodenv-vars"
+  url "https://github.com/nodenv/nodenv-vars/archive/v1.2.0.tar.gz"
   sha256 "80b0f2b942067f18d9c725ecad3c192a8ecbf0bb9ad00b9c797d994546bc9ff5"
-  head "https://github.com/jasonkarns/nodenv-vars.git"
+  head "https://github.com/nodenv/nodenv-vars.git"
 
   depends_on "nodenv"
 


### PR DESCRIPTION
skipped nodenv-npm-rehash as that one hasn't been moved to the nodenv org. (should it be?)