### PR TITLE
Adds post_install to activate automatic rehash

### DIFF
--- a/nodenv-package-rehash.rb
+++ b/nodenv-package-rehash.rb
@@ -10,6 +10,10 @@ class NodenvPackageRehash < Formula
   def install
     prefix.install Dir["*"]
   end
+  
+  def post_install
+    system "nodenv", "package-hooks", "install", "--all"
+  end
 
   test do
     assert_match /^package-hooks$/, shell_output("nodenv commands")


### PR DESCRIPTION
I noticed that automatic rehashing didn't work on my machine and then I noticed that there was a "do this after install" section missing.

Instead I thought to automate the task so that all is well in the world :)