### PR TITLE
Adds formula for installing `nodenv-default-npmrc`

### DIFF
--- a/nodenv-default-npmrc.rb
+++ b/nodenv-default-npmrc.rb
@@ -1,0 +1,18 @@
+class NodenvDefaultNpmrc < Formula
+  desc "Automatically installs a root npmrc for each node version"
+  homepage "https://github.com/deiga/nodenv-default-npmrc"
+  url "https://github.com/deiga/nodenv-default-npmrc/archive/v1.0.0.tar.gz"
+  sha256 "250609824441580739bcdff5de381c0147ab76c0e761e6f696c0a262a753c9c6"
+
+  depends_on "nodenv"
+  depends_on "node-build"
+
+  def install
+    ENV["PREFIX"] = prefix
+    system "./install.sh"
+  end
+
+  test do
+    assert_match /default-npmrc\.bash/, shell_output("nodenv hooks install")
+  end
+end


### PR DESCRIPTION
Why:

* For easier distribution of the package

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nodenv/homebrew-nodenv/39)
<!-- Reviewable:end -->
