### PR TITLE
Make latest brew-audit happy

### DIFF
--- a/node-build-update-defs.rb
+++ b/node-build-update-defs.rb
@@ -5,8 +5,8 @@ class NodeBuildUpdateDefs < Formula
   sha256 "e1a0b5e5c68d48cd5cff46dc6e196dfbb04369ff711ae1287679a580449ee30d"
   head "https://github.com/nodenv/node-build-update-defs.git"
 
-  depends_on "nodenv"
   depends_on "node-build"
+  depends_on "nodenv"
 
   def install
     mv "lib", "src"

--- a/nodenv-default-npmrc.rb
+++ b/nodenv-default-npmrc.rb
@@ -4,8 +4,8 @@ class NodenvDefaultNpmrc < Formula
   url "https://github.com/deiga/nodenv-default-npmrc/archive/v1.0.0.tar.gz"
   sha256 "250609824441580739bcdff5de381c0147ab76c0e761e6f696c0a262a753c9c6"
 
-  depends_on "nodenv"
   depends_on "node-build"
+  depends_on "nodenv"
 
   def install
     ENV["PREFIX"] = prefix

--- a/nodenv-default-packages.rb
+++ b/nodenv-default-packages.rb
@@ -5,8 +5,8 @@ class NodenvDefaultPackages < Formula
   sha256 "498cd82a810963a1617ab8a5ff29987f14b804ba78e38cfa50c6411f780b0d16"
   head "https://github.com/nodenv/nodenv-default-packages.git"
 
-  depends_on "nodenv"
   depends_on "node-build"
+  depends_on "nodenv"
 
   def install
     ENV["PREFIX"] = prefix


### PR DESCRIPTION
Looks like brew-audit now requires alphabetized depedencies, despite the
current ordering being rather "natural".