### PR TITLE
Adds caveats for node-build plugins

### DIFF
--- a/node-build-jxcore.rb
+++ b/node-build-jxcore.rb
@@ -14,6 +14,15 @@ class NodeBuildJxcore < Formula
     system "./install.sh"
   end
 
+  def caveats
+    <<~MSG
+      For `node-build`/`nodenv install` to pick up definitions provided by this plugin,
+      ensure '#{share/"node-build"}' exists in NODE_BUILD_DEFINITIONS.
+
+          export NODE_BUILD_DEFINITIONS="#{share/"node-build"}"
+    MSG
+  end
+
   test do
     system "ls", "#{share}/node-build"
   end

--- a/node-build-prerelease.rb
+++ b/node-build-prerelease.rb
@@ -14,6 +14,15 @@ class NodeBuildPrerelease < Formula
     system "./install.sh"
   end
 
+  def caveats
+    <<~MSG
+      For `node-build`/`nodenv install` to pick up definitions provided by this plugin,
+      ensure '#{share/"node-build"}' exists in NODE_BUILD_DEFINITIONS.
+
+          export NODE_BUILD_DEFINITIONS="#{share/"node-build"}"
+    MSG
+  end
+
   test do
     system "ls", "#{share}/node-build"
   end

--- a/node-build-update-defs.rb
+++ b/node-build-update-defs.rb
@@ -14,7 +14,16 @@ class NodeBuildUpdateDefs < Formula
     prefix.install Dir["*"]
   end
 
+  def caveats
+    <<~MSG
+      For `node-build`/`nodenv install` to pick up definitions written by this plugin,
+      ensure '#{share/"node-build"}' exists in NODE_BUILD_DEFINITIONS.
+
+          export NODE_BUILD_DEFINITIONS="#{share/"node-build"}"
+    MSG
+  end
+
   test do
-    assert_match /^update-version-defs$/, shell_output("nodenv commands")
+    assert_match(/^update-version-defs$/, shell_output("nodenv commands"))
   end
 end


### PR DESCRIPTION
Emits warnings to ensure the plugin's share/node-build directory is
added to NODE_BUILD_DEFINITIONS

closes #59 

re: nodenv/node-build-update-defs#16