### PR TITLE
Remove deprecated `bottle` statement

### DIFF
--- a/Formula/node-build-jxcore.rb
+++ b/Formula/node-build-jxcore.rb
@@ -5,8 +5,6 @@ class NodeBuildJxcore < Formula
   sha256 "1b09594c19bb0627489a2f3e19bd7384087a7212df10720046b36c70e13b2cd4"
   head "https://github.com/nodenv/node-build-jxcore.git"
 
-  bottle :unneeded
-
   depends_on "node-build"
 
   def install

--- a/Formula/node-build-prerelease.rb
+++ b/Formula/node-build-prerelease.rb
@@ -5,8 +5,6 @@ class NodeBuildPrerelease < Formula
   sha256 "d30bf4b3a7398da47ece837bd5e396e0b7f5257126caa2148304ee271956798c"
   head "https://github.com/nodenv/node-build-prerelease.git"
 
-  bottle :unneeded
-
   depends_on "node-build"
 
   def install


### PR DESCRIPTION
As of Homebrew v3.4.0 the `bottle` statement is deprecated and this makes the repo unusable. This PR removes the deprecated statements from 2 formulas.

Closes: #96 

Ref: https://github.com/Homebrew/brew/pull/12913
