### PR TITLE
Rollback nodenv-nvmrc hash due to github compression lib change

### DIFF
--- a/Formula/nodenv-nvmrc.rb
+++ b/Formula/nodenv-nvmrc.rb
@@ -2,7 +2,7 @@ class NodenvNvmrc < Formula
   desc "Pick a node version from .nvmrc"
   homepage "https://github.com/ouchxp/nodenv-nvmrc"
   url "https://github.com/ouchxp/nodenv-nvmrc/archive/v1.0.6.tar.gz"
-  sha256 "bb52d78c2c476cb0a22dc0837d01fbc8939774ccdf385d221cfdbe1aac03305c"
+  sha256 "8381f5d30edd76251bd218db893823c2d0cc82e5b8a29bd03daa1afe6f02d66d"
   head "https://github.com/ouchxp/nodenv-nvmrc.git"
 
   depends_on "nodenv"


### PR DESCRIPTION
Github has [changed its compression lib](https://github.com/community/community/discussions/46034) which affected hashes. They have rolled it back so the hash needs to be reverted.
```
> shasum -a 256  nodenv-nvmrc-1.0.6.tar.gz
8381f5d30edd76251bd218db893823c2d0cc82e5b8a29bd03daa1afe6f02d66d  nodenv-nvmrc-1.0.6.tar.gz
```